### PR TITLE
Feat/handle twelve months first policy - [CDI-479]

### DIFF
--- a/contract/services.py
+++ b/contract/services.py
@@ -1514,8 +1514,7 @@ class ContractContributionPlanDetails(object):
 
                 print("=======>last_date_covered : ", last_date_covered)
                 print("=======>expiry_date : ", expiry_date)
-                
-                breakpoint()
+            
 
             logger.info(
                 f"create_contract_details_policies : AU : last_date_covered : {last_date_covered}"

--- a/contract/services.py
+++ b/contract/services.py
@@ -1512,9 +1512,9 @@ class ContractContributionPlanDetails(object):
                     insuree, last_date_covered
                 )
 
-                print("last_date_covered : ", last_date_covered)
-                print("expiry_date : ", expiry_date)
-
+                print("=======>last_date_covered : ", last_date_covered)
+                print("=======>expiry_date : ", expiry_date)
+                
                 breakpoint()
 
             logger.info(
@@ -1567,9 +1567,9 @@ class ContractContributionPlanDetails(object):
             family=insuree.family
         ).first()
 
-        if check_already_insuree_policy is None:
+        if check_already_insuree_policy:
             return last_date_covered
-
+        
         return last_date_covered + relativedelta(months=3)
 
     @check_authentication

--- a/contract/services.py
+++ b/contract/services.py
@@ -242,7 +242,7 @@ class Contract(object):
                         "amendment": 0,
                     }
                 )
-                
+
                 # get_and_set_waiting_period_for_insuree
                 contract_details_to_update = ContractDetailsModel.objects.filter(
                     contract_id=uuid_string, is_deleted=False
@@ -1508,7 +1508,14 @@ class ContractContributionPlanDetails(object):
 
                 expiry_date = expiry_date.replace(day=desired_start_policy_day - 1)
 
+                last_date_covered = self.__handle_twelve_month_first_policy(
+                    insuree, last_date_covered
+                )
+
+                print("last_date_covered : ", last_date_covered)
                 print("expiry_date : ", expiry_date)
+
+                breakpoint()
 
             logger.info(
                 f"create_contract_details_policies : AU : last_date_covered : {last_date_covered}"
@@ -1554,6 +1561,16 @@ class ContractContributionPlanDetails(object):
 
         logger.info("create_contract_details_policies : --------- End ---------")
         return policy_output, last_date_covered
+
+    def __handle_twelve_month_first_policy(self, insuree, last_date_covered):
+        check_already_insuree_policy = Policy.objects.filter(
+            family=insuree.family
+        ).first()
+
+        if check_already_insuree_policy is None:
+            return last_date_covered
+
+        return last_date_covered + relativedelta(months=3)
 
     @check_authentication
     def contract_valuation(self, contract_contribution_plan_details):


### PR DESCRIPTION
## Description

Bonjour @Tom la validité de la première police créée pour les assurés dont la périodicité est 12 est incorrect. 

pour rappelle les plan de contribution dont la périodicité est 12, la permière police doit être de 9 mois et pas 12. (par exemple pour un étudiant ou un tipl dont la déclaration ouvre janvier 2024 jusqu'à décembre 2024), la police doit aller d’avril 2024 à decembre 2024), car le 3 premier mois correspond à la période de carence. néanmoins la deuxième police aura 12 mois complet de validité parcequ’aucune carence ne sera deduite.

la capture ci-dessous montre que la première police a commencé le 06 avril 2024, et va se terminer le 05 avril 2025 au lieu de se terminer le 05 janvier 2025. prière corriger cette erreur.

## Ticket

https://akieni.atlassian.net/jira/software/projects/CDI/boards/14?selectedIssue=CDI-479